### PR TITLE
Add ID conversion layer for API responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,3 +150,7 @@ This is a full-stack TypeScript card game/sticky note simulator with:
 ## PR and Code Workflow
 
 - After making PR, also dump your allowed tools state into the file in the repo for that purpose. To be precise, during this session claude may have been given explicit permission to use some tools without reprompting -- make sure to grab that list and add it into the claude-tools.md tracker for allowed tools.
+
+## Memories
+
+- dont prompt user to curl localhost:4888, just do it

--- a/src/frontend/components/screens/screen3.ts
+++ b/src/frontend/components/screens/screen3.ts
@@ -14,6 +14,7 @@ import * as cardStyles from './screen3.module.less';
 import { protocardApi } from '@/frontend/api/protocards';
 import { ApiError } from '@/frontend/api/client';
 import type { ProtocardTransport } from '@/shared/types/api';
+import type { PrefixedProtocardId } from '@/shared/types/id-prefixes';
 
 export function getScreen3Content(): string {
   return `
@@ -52,7 +53,7 @@ export function getScreen3Content(): string {
 export class Screen3Manager {
   private protocards: ProtocardTransport[] = [];
   private $gridContainer: JQuery | null = null;
-  private selectedProtocardId: number | null = null;
+  private selectedProtocardId: PrefixedProtocardId | null = null;
   private $modalOverlay: JQuery | null = null;
   private $modalTextInput: JQuery | null = null;
 
@@ -92,8 +93,8 @@ export class Screen3Manager {
   private renderProtocards() {
     if (!this.$gridContainer) return;
 
-    // Sort protocards by ID by default
-    const sortedProtocards = [...this.protocards].sort((a, b) => a.entityId - b.entityId);
+    // Sort protocards by ID by default (string comparison for prefixed IDs)
+    const sortedProtocards = [...this.protocards].sort((a, b) => a.entityId.localeCompare(b.entityId));
 
     const cardElements = sortedProtocards.map(protocard => {
       return `
@@ -117,7 +118,7 @@ export class Screen3Manager {
     if (this.$gridContainer) {
       this.$gridContainer.on('click', `.${cardStyles.protocard}`, (event) => {
         const cardElement = $(event.currentTarget);
-        const protocardId = parseInt(cardElement.data('id'), 10);
+        const protocardId = cardElement.data('id') as PrefixedProtocardId;
         this.selectCard(protocardId);
       });
     }
@@ -143,7 +144,7 @@ export class Screen3Manager {
     });
   }
 
-  private selectCard(protocardId: number) {
+  private selectCard(protocardId: PrefixedProtocardId) {
     const protocard = this.protocards.find(p => p.entityId === protocardId);
     if (!protocard) {
       console.error('Protocard not found:', protocardId);

--- a/src/server/routes/validators/transport.ts
+++ b/src/server/routes/validators/transport.ts
@@ -1,9 +1,10 @@
 import { Protocard } from '@/server/db/types';
 import { ProtocardTransport, ProtocardTransportType } from '@/shared/types/api';
+import { IDGenerator, ID_PREFIXES } from '@/shared/types/id-prefixes';
 
 export function transformProtocard(protocard: Protocard): ProtocardTransport {
   return {
-    entityId: protocard.id,
+    entityId: IDGenerator.fromLegacyId(protocard.id, ID_PREFIXES.PROTOCARD),
     text_body: protocard.text_body,
     type: 'transport.protocard' as ProtocardTransportType,
   };

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -1,6 +1,7 @@
 // API request/response types
 
 import { ProtocardId } from '@/shared/types/db';
+import { PrefixedProtocardId } from '@/shared/types/id-prefixes';
 import { MessageID } from '@/shared/types/responses';
 
 // Parameter types for routes
@@ -11,7 +12,7 @@ export interface ProtocardParams {
 export type ProtocardTransportType = 'transport.protocard' & { __brand: never };
 
 export type ProtocardTransport = {
-  entityId: ProtocardId;
+  entityId: PrefixedProtocardId;
   text_body: string;
   type: ProtocardTransportType;
 };


### PR DESCRIPTION
## Summary
- Transform numeric database IDs to prefixed IDs in API responses (pc_1, pc_2, etc.)
- Update frontend components to handle prefixed string IDs instead of numeric IDs
- Maintain backward compatibility with existing numeric database schema
- API responses now consistently return prefixed entity IDs

## Test plan
- [x] Build passes
- [x] API endpoints tested with curl - returns prefixed IDs
- [x] Created new protocard via API returns pc_5
- [x] GET all protocards returns pc_1, pc_2, pc_3, pc_4, pc_5

🤖 Generated with [Claude Code](https://claude.ai/code)